### PR TITLE
migrate from analytics.js to gtag.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,9 +32,9 @@ module.exports = {
       },
     },
     {
-      resolve: `gatsby-plugin-google-analytics`,
+      resolve: `gatsby-plugin-google-gtag`,
       options: {
-        trackingId: `UA-45640649-1`,
+        trackingIds: [`G-92YG5F10TV`],
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "gatsby": "^5.5.0",
         "gatsby-image": "^3.11.0",
-        "gatsby-plugin-google-analytics": "^5.5.0",
+        "gatsby-plugin-google-gtag": "^5.10.0",
         "gatsby-plugin-manifest": "^5.5.0",
         "gatsby-plugin-offline": "^6.5.0",
         "gatsby-plugin-sass": "^6.5.0",
@@ -1846,9 +1846,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
+      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -8816,14 +8816,13 @@
         "@parcel/core": "^2.0.0"
       }
     },
-    "node_modules/gatsby-plugin-google-analytics": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-5.5.0.tgz",
-      "integrity": "sha512-/OfFZd7ciXkft6Pq6J2lCMTewuhNfQd/2cKWqLiWSD0okw6OXH8swJ/VOk6yIDW8i3EULvlsbofxIVZD0Loeig==",
+    "node_modules/gatsby-plugin-google-gtag": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-5.10.0.tgz",
+      "integrity": "sha512-GZRLaDhEV7QtGsyMkO7sdp7grcLiTQm9LNFjPLvGTRfm+H3tM782yVt3BUIBLqpex/ST+Sr0Om//6FJ98Ji3BA==",
       "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "minimatch": "^3.1.2",
-        "web-vitals": "^1.1.2"
+        "@babel/runtime": "^7.20.13",
+        "minimatch": "^3.1.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -15545,11 +15544,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw=="
-    },
-    "node_modules/web-vitals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.2.tgz",
-      "integrity": "sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "gatsby": "^5.5.0",
     "gatsby-image": "^3.11.0",
-    "gatsby-plugin-google-analytics": "^5.5.0",
+    "gatsby-plugin-google-gtag": "^5.10.0",
     "gatsby-plugin-manifest": "^5.5.0",
     "gatsby-plugin-offline": "^6.5.0",
     "gatsby-plugin-sass": "^6.5.0",


### PR DESCRIPTION
Switch from this [deprecated google analytics plugin](https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics/) to  [this one](https://www.gatsbyjs.com/plugins/gatsby-plugin-google-gtag/).

[More info here](https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs).
